### PR TITLE
Revert "None is not a string"

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -82,7 +82,7 @@ class DarwinToolchainConan(ConanFile):
         common_flags = []
 
         # Bitcode
-        if self.options.enable_bitcode is None:
+        if self.options.enable_bitcode == "None":
             self.output.info("Bitcode enabled: IGNORED")
         else:
             if self.options.enable_bitcode:
@@ -99,7 +99,7 @@ class DarwinToolchainConan(ConanFile):
                 self.output.info("Bitcode enabled: NO")
 
         # ARC
-        if self.options.enable_arc is None:
+        if self.options.enable_arc == "None":
             self.output.info("ObjC ARC enabled: IGNORED")
         else:
             if self.options.enable_arc:
@@ -112,7 +112,7 @@ class DarwinToolchainConan(ConanFile):
                 self.output.info("ObjC ARC enabled: NO")
 
         # Visibility
-        if self.options.enable_visibility is None:
+        if self.options.enable_visibility == "None":
             self.output.info("Visibility enabled: IGNORED")
         else:
             if self.options.enable_visibility:


### PR DESCRIPTION
This reverts commit e856405bda33bb8b419f696c2a322aa51777b67d.

`self.options` are Objects of type PackageOption and never are None
Since it stores the value as str is better to compare to "None"

https://github.com/conan-io/conan/blob/addd8ab4726a557d165e17ec6bb202f0c1666f0c/conans/model/options.py#L326